### PR TITLE
a small fix to be sure the next startup is setup

### DIFF
--- a/wittyPi/daemon.sh
+++ b/wittyPi/daemon.sh
@@ -55,16 +55,17 @@ fi
 # synchronize time
 if $has_rtc ; then
   "$cur_dir/syncTime.sh" &
+ 
+ # wait for system time update
+ sleep 3
 else
   log 'Witty Pi is not connected, skip synchronizing time...'
 fi
 
-# wait for system time update
-sleep 3
-
 # run schedule script
 if $has_rtc ; then
-  "$cur_dir/runScript.sh" >> "$cur_dir/schedule.log" &
+  #should not be launch in background to be sure the next schedule is setup
+  "$cur_dir/runScript.sh" >> "$cur_dir/schedule.log"
 else
   log 'Witty Pi is not connected, skip schedule script...'
 fi


### PR DESCRIPTION
Hello,
For my timelapse project, i don't send email in order to shutdown quickly and save my power. But i have a problem, the next startup is never setup.
Here's the reason : 
If the extraTask shutdown too quickly the RPI, the runScript.sh don't have the time to setup the next startup. 
So, i think the runScript.sh shouldn't be launch in background to be sure the next startup is setup.
Hope this will help :)